### PR TITLE
refactor(deps): migrate to maintained YAML module

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,21 @@ jobs:
           cache: false
           go-version-file: 'go.mod'
 
+      - name: Test
+        run: go test ./...
+
+      - name: Test YAML compatibility module
+        run: go -C compat/yamlv3 test ./...
+
+      - name: Test downstream YAML API compatibility
+        shell: bash
+        run: |
+          consumer_dir=$(mktemp -d)
+          cp -R testdata/downstream/. "${consumer_dir}"
+          go -C "${consumer_dir}" mod edit \
+              -replace github.com/mzz2017/gg="${GITHUB_WORKSPACE}"
+          go -C "${consumer_dir}" test -mod=mod ./...
+
       - name: pre-start
         shell: bash
         run: |

--- a/cmd/subscription_test.go
+++ b/cmd/subscription_test.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/mzz2017/gg/dialer"
+	_ "github.com/mzz2017/gg/dialer/socks"
+)
+
+func TestResolveSubscriptionAsClash(t *testing.T) {
+	config := []byte(`proxies:
+  - name: local-socks
+    type: socks5
+    server: 192.0.2.1
+    port: 1080
+    username: alice
+    password: secret
+    udp: true
+`)
+	tests := map[string][]byte{
+		"plain":  config,
+		"base64": []byte(base64.StdEncoding.EncodeToString(config)),
+	}
+
+	for name, subscription := range tests {
+		t.Run(name, func(t *testing.T) {
+			dialers, err := resolveSubscriptionAsClash(NewLogger(0), &dialer.GlobalOption{}, subscription)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(dialers) != 1 {
+				t.Fatalf("dialers = %d, want 1", len(dialers))
+			}
+			if got := dialers[0].Name(); got != "local-socks" {
+				t.Fatalf("name = %q, want local-socks", got)
+			}
+			if got := dialers[0].Protocol(); got != "socks5" {
+				t.Fatalf("protocol = %q, want socks5", got)
+			}
+			if !dialers[0].SupportUDP() {
+				t.Fatal("expected UDP support")
+			}
+		})
+	}
+}

--- a/compat/yamlv3/api_test.go
+++ b/compat/yamlv3/api_test.go
@@ -1,0 +1,80 @@
+package yaml_test
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type apiValue struct{}
+
+func (*apiValue) MarshalYAML() (any, error)      { return nil, nil }
+func (*apiValue) UnmarshalYAML(*yaml.Node) error { return nil }
+func (*apiValue) IsZero() bool                   { return true }
+
+var (
+	_ yaml.Marshaler   = (*apiValue)(nil)
+	_ yaml.Unmarshaler = (*apiValue)(nil)
+	_ yaml.IsZeroer    = (*apiValue)(nil)
+	_ error            = (*yaml.TypeError)(nil)
+
+	_ func(any) ([]byte, error)     = yaml.Marshal
+	_ func([]byte, any) error       = yaml.Unmarshal
+	_ func(io.Reader) *yaml.Decoder = yaml.NewDecoder
+	_ func(io.Writer) *yaml.Encoder = yaml.NewEncoder
+
+	_ yaml.Kind = yaml.DocumentNode
+	_ yaml.Kind = yaml.SequenceNode
+	_ yaml.Kind = yaml.MappingNode
+	_ yaml.Kind = yaml.ScalarNode
+	_ yaml.Kind = yaml.AliasNode
+
+	_ yaml.Style = yaml.TaggedStyle
+	_ yaml.Style = yaml.DoubleQuotedStyle
+	_ yaml.Style = yaml.SingleQuotedStyle
+	_ yaml.Style = yaml.LiteralStyle
+	_ yaml.Style = yaml.FoldedStyle
+	_ yaml.Style = yaml.FlowStyle
+)
+
+func assertAPISurface(decoder *yaml.Decoder, encoder *yaml.Encoder, node *yaml.Node, typeError *yaml.TypeError) {
+	_ = decoder.Decode
+	_ = decoder.KnownFields
+	_ = encoder.Close
+	_ = encoder.Encode
+	_ = encoder.SetIndent
+	_ = node.Decode
+	_ = node.Encode
+	_ = node.IsZero
+	_ = node.LongTag
+	_ = node.SetString
+	_ = node.ShortTag
+	_ = typeError.Error
+
+	_ = yaml.Node{
+		Kind:        yaml.ScalarNode,
+		Style:       yaml.TaggedStyle,
+		Tag:         "tag",
+		Value:       "value",
+		Anchor:      "anchor",
+		Alias:       node,
+		Content:     []*yaml.Node{node},
+		HeadComment: "head",
+		LineComment: "line",
+		FootComment: "foot",
+		Line:        1,
+		Column:      1,
+	}
+	_ = yaml.TypeError{Errors: []string{"error"}}
+}
+
+func TestLegacyV3APISurface(*testing.T) {
+	assertAPISurface(
+		yaml.NewDecoder(strings.NewReader("")),
+		yaml.NewEncoder(io.Discard),
+		&yaml.Node{},
+		&yaml.TypeError{},
+	)
+}

--- a/compat/yamlv3/doc.go
+++ b/compat/yamlv3/doc.go
@@ -1,0 +1,3 @@
+// Package yaml preserves the legacy YAML v3 import contract while delegating
+// all parsing and encoding to the maintained go.yaml.in/yaml/v3 module.
+package yaml

--- a/compat/yamlv3/go.mod
+++ b/compat/yamlv3/go.mod
@@ -1,0 +1,5 @@
+module gopkg.in/yaml.v3
+
+go 1.26
+
+require go.yaml.in/yaml/v3 v3.0.4

--- a/compat/yamlv3/go.sum
+++ b/compat/yamlv3/go.sum
@@ -1,0 +1,4 @@
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/compat/yamlv3/yaml.go
+++ b/compat/yamlv3/yaml.go
@@ -1,0 +1,53 @@
+package yaml
+
+import (
+	"io"
+
+	upstream "go.yaml.in/yaml/v3"
+)
+
+// This is the complete exported API of gopkg.in/yaml.v3 v3.0.1. Type aliases
+// retain every exported method and field; the maintained module only adds two
+// Encoder indentation methods.
+type (
+	Unmarshaler = upstream.Unmarshaler
+	Marshaler   = upstream.Marshaler
+	Decoder     = upstream.Decoder
+	Encoder     = upstream.Encoder
+	TypeError   = upstream.TypeError
+	Kind        = upstream.Kind
+	Style       = upstream.Style
+	Node        = upstream.Node
+	IsZeroer    = upstream.IsZeroer
+)
+
+const (
+	DocumentNode = upstream.DocumentNode
+	SequenceNode = upstream.SequenceNode
+	MappingNode  = upstream.MappingNode
+	ScalarNode   = upstream.ScalarNode
+	AliasNode    = upstream.AliasNode
+
+	TaggedStyle       = upstream.TaggedStyle
+	DoubleQuotedStyle = upstream.DoubleQuotedStyle
+	SingleQuotedStyle = upstream.SingleQuotedStyle
+	LiteralStyle      = upstream.LiteralStyle
+	FoldedStyle       = upstream.FoldedStyle
+	FlowStyle         = upstream.FlowStyle
+)
+
+func Unmarshal(in []byte, out any) error {
+	return upstream.Unmarshal(in, out)
+}
+
+func Marshal(in any) ([]byte, error) {
+	return upstream.Marshal(in)
+}
+
+func NewDecoder(r io.Reader) *Decoder {
+	return upstream.NewDecoder(r)
+}
+
+func NewEncoder(w io.Writer) *Encoder {
+	return upstream.NewEncoder(w)
+}

--- a/compat/yamlv3/yaml_test.go
+++ b/compat/yamlv3/yaml_test.go
@@ -1,0 +1,24 @@
+package yaml_test
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type nodeValue string
+
+func (v *nodeValue) UnmarshalYAML(node *yaml.Node) error {
+	*v = nodeValue(node.Value)
+	return nil
+}
+
+func TestUnmarshalUsesMaintainedNodeType(t *testing.T) {
+	var value nodeValue
+	if err := yaml.Unmarshal([]byte("value\n"), &value); err != nil {
+		t.Fatal(err)
+	}
+	if value != "value" {
+		t.Fatalf("value = %q, want value", value)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,10 @@ module github.com/mzz2017/gg
 
 go 1.26
 
+// Root builds preserve the public YAML v3 type identity while using the maintained implementation.
+// Downstream modules retain their independently selected gopkg.in/yaml.v3 implementation.
+replace gopkg.in/yaml.v3 => ./compat/yamlv3
+
 require (
 	github.com/1lann/promptui v0.8.1-0.20220708222609-81fad96dd5e1
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/go.sum
+++ b/go.sum
@@ -241,9 +241,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b h1:QRR6H1YWRnHb4Y/HeNFCTJLFVxaq6wH4YuVdsUOr75U=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 lukechampine.com/blake3 v1.2.1 h1:YuqqRuaqsGV71BV/nm9xlI0MKUv4QC54jQnBChWbGnI=
 lukechampine.com/blake3 v1.2.1/go.mod h1:0OFRp7fBtAylGVCO40o87sbupkyIGgbpv1+M1k1LM6k=

--- a/testdata/downstream/compat_test.go
+++ b/testdata/downstream/compat_test.go
@@ -1,0 +1,12 @@
+package downstream
+
+import (
+	"github.com/mzz2017/gg/dialer"
+	"gopkg.in/yaml.v3"
+)
+
+func legacyCreator(*yaml.Node, *dialer.GlobalOption) (*dialer.Dialer, error) {
+	return nil, nil
+}
+
+var _ dialer.FromClashCreator = legacyCreator

--- a/testdata/downstream/go.mod
+++ b/testdata/downstream/go.mod
@@ -1,0 +1,10 @@
+module example.com/gg-yaml-downstream
+
+go 1.26
+
+require (
+	github.com/mzz2017/gg v0.0.0
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+replace gopkg.in/yaml.v3 => ./legacyyaml

--- a/testdata/downstream/legacyyaml/go.mod
+++ b/testdata/downstream/legacyyaml/go.mod
@@ -1,0 +1,3 @@
+module gopkg.in/yaml.v3
+
+go 1.26

--- a/testdata/downstream/legacyyaml/yaml.go
+++ b/testdata/downstream/legacyyaml/yaml.go
@@ -1,0 +1,7 @@
+package yaml
+
+type Node struct{}
+
+func (*Node) Decode(any) error {
+	return nil
+}


### PR DESCRIPTION
## Summary

- route every `gopkg.in/yaml.v3` request through a local compatibility module backed by maintained `go.yaml.in/yaml/v3 v3.0.4`
- preserve the existing public `gopkg.in/yaml.v3.Node` API identity for downstream callers
- remove every old YAML implementation checksum from the root `go.sum`
- add compatibility coverage for plain and Base64-encoded Clash subscriptions

## Rationale

The project depends on the `gopkg.in/yaml.v3` import identity, whose last release was in 2022. The YAML project now publishes maintained v3 releases from `go.yaml.in/yaml/v3`.

Go cannot directly replace the old path with the maintained vanity path because both module identities already occur in the dependency graph. The compatibility module preserves the old public type identity while aliasing and forwarding its complete public API to the maintained implementation.

This also avoids a breaking change for downstream implementations of `dialer.FromClashCreator`, whose signature exposes `*yaml.Node`.

The `replace` is intentionally root-module scoped, as required by Go module semantics. Builds of this repository use the maintained implementation; downstream modules keep their independently selected `gopkg.in/yaml.v3` implementation while retaining the unchanged public type identity.

## Impact

Clash subscription and proxy decoding continue to use the YAML v3 API without downloading or compiling the old implementation. The new regression tests exercise both accepted subscription encodings and verify that custom `UnmarshalYAML(*Node)` implementations retain type compatibility.

## Validation

- `go mod verify`
- compatibility module `go mod verify` and `go test ./...`
- clean `GOMODCACHE` download audit: no `gopkg.in/yaml.v3` files; only `go.yaml.in/yaml/v3@v3.0.4`
- Survey v2 and Testify YAML assertion tests through the compatibility module
- downstream compile test for an existing `gopkg.in/yaml.v3.Node` `dialer.FromClashCreator`
- downstream simulation uses a local identity-only YAML stub, so CI does not download the old implementation
- Linux arm64 `go test ./... -coverprofile=/out/current.out`
- coverage: `9.8% (234/2389)` on `master` to `10.5% (251/2389)` on this branch
- CI runs both root-module and compatibility-module tests on linux/amd64 and linux/arm64
- `ko build --local --platform linux/amd64 --bare ./`
- `ko build --local --platform linux/arm64 --bare ./`
- `docker run --rm --platform linux/amd64 localhost/gg-yaml-amd64:latest --help`
- `docker run --rm --platform linux/arm64 localhost/gg-yaml-arm64:latest --help`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a compatibility layer for the legacy YAML v3 API, preserving existing imports and public types.
  * Improved compatibility for downstream integrations using YAML-based dialer configuration.

* **Bug Fixes**
  * Fixed subscription resolution for YAML and Base64-encoded YAML SOCKS5 configurations, including UDP support.

* **Tests**
  * Added comprehensive API, regression, downstream compatibility, and release validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->