### PR TITLE
refactor(deps): remove fatih structs

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -3,9 +3,9 @@ package common
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/fatih/structs"
 	"net/url"
 	"reflect"
+	"slices"
 	"strings"
 )
 
@@ -52,11 +52,53 @@ func Base64URLDecode(s string) (string, error) {
 }
 
 func ObjectToKV(v any, tagName string) (kv []string) {
-	a := structs.New(v)
-	if tagName != "" {
-		a.TagName = tagName
+	value := reflect.ValueOf(v)
+	for value.IsValid() && value.Kind() == reflect.Ptr {
+		if value.IsNil() {
+			return nil
+		}
+		value = value.Elem()
 	}
-	return MapToKV(a.Map())
+	if !value.IsValid() || value.Kind() != reflect.Struct {
+		return nil
+	}
+	return appendStructKV(nil, value, tagName, "")
+}
+
+func appendStructKV(kv []string, value reflect.Value, tagName, prefix string) []string {
+	typeOfValue := value.Type()
+	for i := 0; i < value.NumField(); i++ {
+		fieldType := typeOfValue.Field(i)
+		if !fieldType.IsExported() {
+			continue
+		}
+
+		name := fieldType.Name
+		if tagName != "" {
+			tag := strings.Split(fieldType.Tag.Get(tagName), ",")
+			if tag[0] == "-" {
+				continue
+			}
+			if tag[0] != "" {
+				name = tag[0]
+			}
+			if slices.Contains(tag[1:], "omitempty") && value.Field(i).IsZero() {
+				continue
+			}
+		}
+
+		key := name
+		if prefix != "" {
+			key = prefix + "." + name
+		}
+		fieldValue := value.Field(i)
+		if fieldValue.Kind() == reflect.Struct {
+			kv = appendStructKV(kv, fieldValue, tagName, key)
+			continue
+		}
+		kv = append(kv, fmt.Sprintf("%s=%v", key, fieldValue.Interface()))
+	}
+	return kv
 }
 
 func MapToKV(m map[string]any) (kv []string) {

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -1,0 +1,65 @@
+package common_test
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/mzz2017/gg/common"
+	"github.com/mzz2017/gg/config"
+)
+
+func TestObjectToKV(t *testing.T) {
+	type nested struct {
+		Enabled bool `mapstructure:"enabled"`
+	}
+	type object struct {
+		Name       string `mapstructure:"name"`
+		Nested     nested `mapstructure:"nested"`
+		Count      int
+		Empty      string `mapstructure:"empty,unused,omitempty"`
+		Ignored    string `mapstructure:"-"`
+		unexported string
+	}
+
+	got := common.ObjectToKV(&object{
+		Name:    "proxy",
+		Nested:  nested{Enabled: true},
+		Count:   2,
+		Ignored: "ignored",
+	}, "mapstructure")
+	sort.Strings(got)
+	want := []string{"Count=2", "name=proxy", "nested.enabled=true"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ObjectToKV() = %#v, want %#v", got, want)
+	}
+}
+
+func TestObjectToKVConfigParams(t *testing.T) {
+	got := common.ObjectToKV(config.Params{}, "mapstructure")
+	sort.Strings(got)
+	want := []string{
+		"allow_insecure=false",
+		"cache.subscription.last_node=",
+		"no_udp=false",
+		"node=",
+		"proxy_private=false",
+		"subscription.cache_last_node=false",
+		"subscription.link=",
+		"subscription.select=",
+		"test_node_before_use=false",
+		"test_url=",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ObjectToKV() = %#v, want %#v", got, want)
+	}
+}
+
+func TestObjectToKVUnsupportedValues(t *testing.T) {
+	var typedNil *struct{}
+	for _, value := range []any{nil, typedNil, 1, map[string]any{}} {
+		if got := common.ObjectToKV(value, "mapstructure"); got != nil {
+			t.Errorf("ObjectToKV(%#v) = %#v, want nil", value, got)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.26
 require (
 	charm.land/huh/v2 v2.0.3
 	github.com/daeuniverse/outbound v0.0.0-20260623082230-cfd9e39fd5e0
-	github.com/fatih/structs v1.1.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/json-iterator/go v1.1.12
 	github.com/nadoo/glider v0.16.4

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,6 @@ github.com/ebfe/rc2 v0.0.0-20131011165748-24b9757f5521 h1:fBHFH+Y/GPGFGo7LIrErQc
 github.com/ebfe/rc2 v0.0.0-20131011165748-24b9757f5521/go.mod h1:ucvhdsUCE3TH0LoLRb6ShHiJl8e39dGlx6A4g/ujlow=
 github.com/eknkc/basex v1.0.1 h1:TcyAkqh4oJXgV3WYyL4KEfCMk9W8oJCpmx1bo+jVgKY=
 github.com/eknkc/basex v1.0.1/go.mod h1:k/F/exNEHFdbs3ZHuasoP2E7zeWwZblG84Y7Z59vQRo=
-github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
-github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=


### PR DESCRIPTION
## Summary

- replace the single fatih/structs use with a small reflection-based config flattener
- preserve mapstructure field names, nested keys, ignored fields, and omitempty behavior
- add coverage for the generic conversion and the complete config.Params key set

## Validation

- Linux arm64: go test -timeout=2m ./... -coverprofile=... (12.3%, parent 11.4%)
- Linux amd64: go test -timeout=2m ./...
- go mod verify
- go vet ./common
- ko build and container --help smoke test on linux/amd64 and linux/arm64
- arm64 binary: 29,416,983 -> 29,348,071 bytes (-68,912)