### PR TITLE
refactor(deps): replace glider socks client

### DIFF
--- a/dialer/socks/socks.go
+++ b/dialer/socks/socks.go
@@ -1,15 +1,18 @@
 package socks
 
 import (
+	"context"
 	"fmt"
-	"github.com/mzz2017/gg/dialer"
-	"github.com/nadoo/glider/proxy"
-	"github.com/nadoo/glider/proxy/socks4"
-	"github.com/nadoo/glider/proxy/socks5"
-	"gopkg.in/yaml.v3"
 	"net"
 	"net/url"
 	"strconv"
+
+	"github.com/mzz2017/gg/dialer"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+	singSocks "github.com/sagernet/sing/protocol/socks"
+	"golang.org/x/net/proxy"
+	"gopkg.in/yaml.v3"
 )
 
 func init() {
@@ -30,6 +33,26 @@ type Socks struct {
 	UDP      bool   `json:"udp"`
 }
 
+type singDialer struct {
+	client *singSocks.Client
+}
+
+func (d *singDialer) Dial(network, address string) (net.Conn, error) {
+	return d.DialContext(context.Background(), network, address)
+}
+
+func (d *singDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return d.client.DialContext(ctx, network, M.ParseSocksaddr(address))
+}
+
+func newSingDialer(rawURL string, next N.Dialer) (proxy.Dialer, error) {
+	client, err := singSocks.NewClientFromURL(next, rawURL)
+	if err != nil {
+		return nil, err
+	}
+	return &singDialer{client: client}, nil
+}
+
 func NewSocks(link string, opt *dialer.GlobalOption) (*dialer.Dialer, error) {
 	s, err := ParseSocksURL(link)
 	if err != nil {
@@ -47,23 +70,28 @@ func NewSocks5FromClashObj(o *yaml.Node, opt *dialer.GlobalOption) (*dialer.Dial
 }
 
 func (s *Socks) Dialer() (*dialer.Dialer, error) {
+	protocol := s.Protocol
 	link := s.ExportToURL()
-	switch s.Protocol {
-	case "", "socks", "socks5":
-		d, err := socks5.NewSocks5Dialer(link, &proxy.Direct{})
-		if err != nil {
-			return nil, err
-		}
-		return dialer.NewDialer(d, s.UDP, s.Name, s.Protocol, link), nil
-	case "socks4", "socks4a":
-		d, err := socks4.NewSocks4Dialer(link, &proxy.Direct{})
-		if err != nil {
-			return nil, err
-		}
-		return dialer.NewDialer(d, false, s.Name, s.Protocol, link), nil
-	default:
-		return nil, fmt.Errorf("unexpected protocol: %v", s.Protocol)
+	if protocol == "" {
+		protocol = "socks5"
+		canonical := *s
+		canonical.Protocol = protocol
+		link = canonical.ExportToURL()
 	}
+	supportUDP := s.UDP
+	switch protocol {
+	case "socks", "socks4", "socks4a", "socks5":
+		if protocol == "socks4" || protocol == "socks4a" {
+			supportUDP = false
+		}
+	default:
+		return nil, fmt.Errorf("unexpected protocol: %v", protocol)
+	}
+	d, err := newSingDialer(link, N.SystemDialer)
+	if err != nil {
+		return nil, err
+	}
+	return dialer.NewDialer(d, supportUDP, s.Name, protocol, link), nil
 }
 
 func ParseClashSocks5(o *yaml.Node) (data *Socks, err error) {
@@ -135,10 +163,15 @@ func (s *Socks) ExportToURL() string {
 	} else {
 		user = url.User(s.Username)
 	}
+	query := url.Values{}
+	if (s.Protocol == "socks" || s.Protocol == "socks5") && !s.UDP {
+		query.Set("udp", "false")
+	}
 	u := url.URL{
 		Scheme:   s.Protocol,
 		User:     user,
 		Host:     net.JoinHostPort(s.Server, strconv.Itoa(s.Port)),
+		RawQuery: query.Encode(),
 		Fragment: s.Name,
 	}
 	return u.String()

--- a/dialer/socks/socks_test.go
+++ b/dialer/socks/socks_test.go
@@ -1,0 +1,260 @@
+package socks
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"slices"
+	"testing"
+
+	M "github.com/sagernet/sing/common/metadata"
+	"github.com/sagernet/sing/protocol/socks/socks4"
+	"github.com/sagernet/sing/protocol/socks/socks5"
+)
+
+type pipeDialer struct {
+	conn net.Conn
+}
+
+func (d *pipeDialer) DialContext(context.Context, string, M.Socksaddr) (net.Conn, error) {
+	return d.conn, nil
+}
+
+func (d *pipeDialer) ListenPacket(context.Context, M.Socksaddr) (net.PacketConn, error) {
+	return nil, fmt.Errorf("unexpected UDP dial")
+}
+
+func TestSingDialerSOCKS5(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- serveSOCKS5(serverConn)
+	}()
+
+	d, err := newSingDialer("socks5://user:password@proxy.example:1080", &pipeDialer{conn: clientConn})
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := d.Dial("tcp", "target.example:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	assertTunnel(t, conn, serverErr)
+}
+
+func serveSOCKS5(conn net.Conn) error {
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+	auth, err := socks5.ReadAuthRequest(reader)
+	if err != nil {
+		return err
+	}
+	if !slices.Contains(auth.Methods, socks5.AuthTypeUsernamePassword) {
+		return fmt.Errorf("auth methods = %v", auth.Methods)
+	}
+	if err := socks5.WriteAuthResponse(conn, socks5.AuthResponse{Method: socks5.AuthTypeUsernamePassword}); err != nil {
+		return err
+	}
+	credentials, err := socks5.ReadUsernamePasswordAuthRequest(reader)
+	if err != nil {
+		return err
+	}
+	if credentials.Username != "user" || credentials.Password != "password" {
+		return fmt.Errorf("credentials = %#v", credentials)
+	}
+	if err := socks5.WriteUsernamePasswordAuthResponse(conn, socks5.UsernamePasswordAuthResponse{}); err != nil {
+		return err
+	}
+	request, err := socks5.ReadRequest(reader)
+	if err != nil {
+		return err
+	}
+	if request.Command != socks5.CommandConnect || request.Destination.String() != "target.example:443" {
+		return fmt.Errorf("request = %#v", request)
+	}
+	if err := socks5.WriteResponse(conn, socks5.Response{
+		ReplyCode: socks5.ReplyCodeSuccess,
+		Bind:      M.ParseSocksaddr("127.0.0.1:0"),
+	}); err != nil {
+		return err
+	}
+	return echoTunnel(conn)
+}
+
+func TestSingDialerSOCKS4A(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- serveSOCKS4A(serverConn)
+	}()
+
+	d, err := newSingDialer("socks4a://user@proxy.example:1080", &pipeDialer{conn: clientConn})
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := d.Dial("tcp", "target.example:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	assertTunnel(t, conn, serverErr)
+}
+
+func TestSingDialerSOCKS4(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+	serverErr := make(chan error, 1)
+	go func() {
+		serverErr <- serveSOCKS4(serverConn)
+	}()
+
+	d, err := newSingDialer("socks4://user@proxy.example:1080", &pipeDialer{conn: clientConn})
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := d.Dial("tcp", "192.0.2.1:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	assertTunnel(t, conn, serverErr)
+}
+
+func serveSOCKS4(conn net.Conn) error {
+	defer conn.Close()
+	request, err := socks4.ReadRequest(bufio.NewReader(conn))
+	if err != nil {
+		return err
+	}
+	if request.Command != socks4.CommandConnect || request.Destination.String() != "192.0.2.1:443" || request.Username != "user" {
+		return fmt.Errorf("request = %#v", request)
+	}
+	if err := socks4.WriteResponse(conn, socks4.Response{
+		ReplyCode:   socks4.ReplyCodeGranted,
+		Destination: M.ParseSocksaddr("127.0.0.1:0"),
+	}); err != nil {
+		return err
+	}
+	return echoTunnel(conn)
+}
+
+func serveSOCKS4A(conn net.Conn) error {
+	defer conn.Close()
+	request, err := socks4.ReadRequest(bufio.NewReader(conn))
+	if err != nil {
+		return err
+	}
+	if request.Command != socks4.CommandConnect || request.Destination.String() != "target.example:443" || request.Username != "user" {
+		return fmt.Errorf("request = %#v", request)
+	}
+	if err := socks4.WriteResponse(conn, socks4.Response{
+		ReplyCode:   socks4.ReplyCodeGranted,
+		Destination: M.ParseSocksaddr("127.0.0.1:0"),
+	}); err != nil {
+		return err
+	}
+	return echoTunnel(conn)
+}
+
+func echoTunnel(conn net.Conn) error {
+	request := make([]byte, len("ping"))
+	if _, err := io.ReadFull(conn, request); err != nil {
+		return err
+	}
+	if string(request) != "ping" {
+		return fmt.Errorf("tunnel request = %q", request)
+	}
+	_, err := conn.Write([]byte("pong"))
+	return err
+}
+
+func assertTunnel(t *testing.T, conn net.Conn, serverErr <-chan error) {
+	t.Helper()
+	if _, err := conn.Write([]byte("ping")); err != nil {
+		t.Fatal(err)
+	}
+	response := make([]byte, len("pong"))
+	if _, err := io.ReadFull(conn, response); err != nil {
+		t.Fatal(err)
+	}
+	if string(response) != "pong" {
+		t.Fatalf("response = %q, want pong", response)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSocksDialerUDPFlag(t *testing.T) {
+	d, err := (&Socks{
+		Server:   "proxy.example",
+		Port:     1080,
+		Protocol: "socks5",
+		UDP:      true,
+	}).Dialer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d.SupportUDP() {
+		t.Fatal("SOCKS5 UDP support is disabled")
+	}
+	if _, ok := d.Dialer.(*singDialer); !ok {
+		t.Fatalf("dialer type = %T, want *singDialer", d.Dialer)
+	}
+	defaultDialer, err := (&Socks{Server: "proxy.example", Port: 1080, UDP: true}).Dialer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !defaultDialer.SupportUDP() {
+		t.Fatal("default SOCKS5 UDP support is disabled")
+	}
+
+	for _, protocol := range []string{"socks4", "socks4a"} {
+		d, err := (&Socks{Server: "proxy.example", Port: 1080, Protocol: protocol, UDP: true}).Dialer()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if d.SupportUDP() {
+			t.Errorf("%s unexpectedly supports UDP", protocol)
+		}
+	}
+}
+
+func TestSocksDialerDefaultProtocolRoundTrip(t *testing.T) {
+	for _, udp := range []bool{true, false} {
+		t.Run(fmt.Sprintf("udp=%t", udp), func(t *testing.T) {
+			want := &Socks{
+				Name:     "default proxy",
+				Server:   "proxy.example",
+				Port:     1080,
+				Username: "user",
+				Password: "password",
+				UDP:      udp,
+			}
+			d, err := want.Dialer()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if d.Protocol() != "socks5" {
+				t.Fatalf("protocol = %q, want socks5", d.Protocol())
+			}
+
+			got, err := ParseSocksURL(d.Link())
+			if err != nil {
+				t.Fatalf("parse link %q: %v", d.Link(), err)
+			}
+			if got.Protocol != "socks5" || got.Name != want.Name || got.Server != want.Server || got.Port != want.Port ||
+				got.Username != want.Username || got.Password != want.Password || got.UDP != want.UDP {
+				t.Fatalf("round trip = %#v", got)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	charm.land/huh/v2 v2.0.3
 	github.com/coder/websocket v1.8.14
 	github.com/daeuniverse/outbound v0.0.0-20260623082230-cfd9e39fd5e0
-	github.com/nadoo/glider v0.16.4
 	github.com/pelletier/go-toml v1.9.5
 	github.com/sagernet/sing v0.8.11
 	github.com/sagernet/sing-shadowsocks2 v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,6 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/mzz2017/disk-bloom v1.0.1 h1:rEF9MiXd9qMW3ibRpqcerLXULoTgRlM21yqqJl1B90M=
 github.com/mzz2017/disk-bloom v1.0.1/go.mod h1:JLHETtUu44Z6iBmsqzkOtFlRvXSlKnxjwiBRDapizDI=
-github.com/nadoo/glider v0.16.4 h1:MmCDNHR5Ejy7CSKy0IIm1SBDN3Cigb6mQdBZdSw5IGU=
-github.com/nadoo/glider v0.16.4/go.mod h1:KuBSZ42y50Ja8Opt6THb0Ri8xyI8f/zQhFiKuSJAnlo=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/onsi/ginkgo/v2 v2.22.2 h1:/3X8Panh8/WwhU/3Ssa6rCKqPLuAkVY2I0RoyDLySlU=


### PR DESCRIPTION
## Summary

- replace github.com/nadoo/glider's SOCKS clients with the existing github.com/sagernet/sing dependency
- adapt Sing's context-aware SOCKS client to the project's proxy.Dialer interface
- preserve SOCKS4, SOCKS4a, SOCKS5, username/password authentication, default protocol handling, and UDP capability flags
- canonicalize the default protocol as SOCKS5 and preserve disabled UDP in persisted links
- use Sing's actual SOCKS5 UDP associate support while continuing to disable UDP for SOCKS4/4a
- add protocol-level SOCKS4, SOCKS4a, and authenticated SOCKS5 handshake plus tunnel round-trip tests

## Dependency result

Glider is absent from source, go.mod, go.sum, go list -deps, and go mod graph. No replacement dependency was added.

## Validation

- Darwin arm64: go test -race ./dialer/socks
- Linux arm64: go test ./... -coverprofile=... (17.3%, parent 15.5%)
- Linux amd64: go test ./... -coverprofile=... (17.7%, parent 15.5%)
- go mod verify and go vet ./dialer/socks
- ko build and container --help smoke test on linux/amd64 and linux/arm64
- arm64 binary: 28,007,002 -> 27,929,371 bytes (-77,631)
