### PR TITLE
refactor(dialer): share context adapter

### DIFF
--- a/dialer/internal/dialutil/dial.go
+++ b/dialer/internal/dialutil/dial.go
@@ -1,0 +1,52 @@
+// Package dialutil contains shared adapters for proxy dialers.
+package dialutil
+
+import (
+	"context"
+	"net"
+
+	"golang.org/x/net/proxy"
+)
+
+// DialContext uses a dialer's native context support when available and
+// otherwise closes any connection that arrives after cancellation.
+func DialContext(ctx context.Context, d proxy.Dialer, network, address string) (net.Conn, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	if d, ok := d.(interface {
+		DialContext(context.Context, string, string) (net.Conn, error)
+	}); ok {
+		return d.DialContext(ctx, network, address)
+	}
+
+	type result struct {
+		conn net.Conn
+		err  error
+	}
+	resultCh := make(chan result)
+	go func() {
+		conn, err := d.Dial(network, address)
+		select {
+		case resultCh <- result{conn: conn, err: err}:
+		case <-ctx.Done():
+			if conn != nil {
+				_ = conn.Close()
+			}
+		}
+	}()
+
+	select {
+	case result := <-resultCh:
+		if err := ctx.Err(); err != nil {
+			if result.conn != nil {
+				_ = result.conn.Close()
+			}
+			return nil, err
+		}
+		return result.conn, result.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/dialer/internal/dialutil/dial_test.go
+++ b/dialer/internal/dialutil/dial_test.go
@@ -1,0 +1,108 @@
+package dialutil
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+type dialerFunc func(string, string) (net.Conn, error)
+
+func (f dialerFunc) Dial(network, address string) (net.Conn, error) {
+	return f(network, address)
+}
+
+type contextDialerFunc func(context.Context, string, string) (net.Conn, error)
+
+func (f contextDialerFunc) Dial(string, string) (net.Conn, error) {
+	panic("unexpected Dial call")
+}
+
+func (f contextDialerFunc) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return f(ctx, network, address)
+}
+
+type closeTrackingConn struct {
+	net.Conn
+	closed chan struct{}
+	once   sync.Once
+}
+
+func (c *closeTrackingConn) Close() error {
+	c.once.Do(func() { close(c.closed) })
+	return c.Conn.Close()
+}
+
+func TestDialContextUsesNativeImplementation(t *testing.T) {
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "value")
+	client, server := net.Pipe()
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+	})
+
+	got, err := DialContext(ctx, contextDialerFunc(func(gotCtx context.Context, network, address string) (net.Conn, error) {
+		if gotCtx.Value(contextKey{}) != "value" || network != "tcp" || address != "example.com:443" {
+			t.Fatalf("DialContext(%v, %q, %q)", gotCtx, network, address)
+		}
+		return client, nil
+	}), "tcp", "example.com:443")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != client {
+		t.Fatalf("connection = %T, want original pipe connection", got)
+	}
+}
+
+func TestDialContextClosesConnectionAfterCancellation(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	client, server := net.Pipe()
+	t.Cleanup(func() { _ = server.Close() })
+	tracked := &closeTrackingConn{Conn: client, closed: make(chan struct{})}
+	d := dialerFunc(func(string, string) (net.Conn, error) {
+		close(started)
+		<-release
+		return tracked, nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, err := DialContext(ctx, d, "tcp", "example.com:443")
+		result <- err
+	}()
+	<-started
+	cancel()
+	close(release)
+	if err := <-result; err != context.Canceled {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+
+	select {
+	case <-tracked.closed:
+	case <-time.After(time.Second):
+		t.Fatal("connection was not closed after cancellation")
+	}
+}
+
+func TestDialContextAlreadyCanceledDoesNotDial(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	called := false
+	_, err := DialContext(ctx, dialerFunc(func(string, string) (net.Conn, error) {
+		called = true
+		return nil, nil
+	}), "tcp", "example.com:443")
+	if err != context.Canceled {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if called {
+		t.Fatal("Dial called with an already canceled context")
+	}
+}

--- a/dialer/netproxy.go
+++ b/dialer/netproxy.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/daeuniverse/outbound/netproxy"
+	"github.com/mzz2017/gg/dialer/internal/dialutil"
 	"golang.org/x/net/proxy"
 )
 
@@ -31,7 +32,7 @@ func (d *netproxyAdapter) DialContext(ctx context.Context, network, addr string)
 		return nil, err
 	}
 
-	conn, err := dialContext(ctx, d.dialer, magicNetwork.Network, addr)
+	conn, err := dialutil.DialContext(ctx, d.dialer, magicNetwork.Network, addr)
 	if err != nil {
 		return nil, err
 	}
@@ -45,37 +46,6 @@ func (d *netproxyAdapter) DialContext(ctx context.Context, network, addr string)
 		return nil, fmt.Errorf("UDP dialer returned %T, which does not implement net.PacketConn", conn)
 	}
 	return &netproxyPacketConn{conn: conn, packetConn: packetConn}, nil
-}
-
-func dialContext(ctx context.Context, d proxy.Dialer, network, addr string) (net.Conn, error) {
-	if d, ok := d.(interface {
-		DialContext(context.Context, string, string) (net.Conn, error)
-	}); ok {
-		return d.DialContext(ctx, network, addr)
-	}
-
-	type result struct {
-		conn net.Conn
-		err  error
-	}
-	resultCh := make(chan result, 1)
-	go func() {
-		conn, err := d.Dial(network, addr)
-		resultCh <- result{conn: conn, err: err}
-	}()
-
-	select {
-	case <-ctx.Done():
-		go func() {
-			result := <-resultCh
-			if result.conn != nil {
-				_ = result.conn.Close()
-			}
-		}()
-		return nil, ctx.Err()
-	case result := <-resultCh:
-		return result.conn, result.err
-	}
 }
 
 type netproxyPacketConn struct {

--- a/dialer/transport/ws/ws.go
+++ b/dialer/transport/ws/ws.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/coder/websocket"
 	"github.com/mzz2017/gg/common"
+	"github.com/mzz2017/gg/dialer/internal/dialutil"
 	"golang.org/x/net/proxy"
 )
 
@@ -29,7 +30,7 @@ func NewWs(s string, d proxy.Dialer) (*Ws, error) {
 
 	transport := &http.Transport{
 		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
-			return dialContext(ctx, d, network, address)
+			return dialutil.DialContext(ctx, d, network, address)
 		},
 	}
 
@@ -76,35 +77,4 @@ func (s *Ws) Dial(network, addr string) (net.Conn, error) {
 		return nil, fmt.Errorf("[Ws]: dial to %s: %w", s.wsAddr, err)
 	}
 	return websocket.NetConn(context.Background(), rc, websocket.MessageBinary), nil
-}
-
-func dialContext(ctx context.Context, d proxy.Dialer, network, address string) (net.Conn, error) {
-	if d, ok := d.(interface {
-		DialContext(context.Context, string, string) (net.Conn, error)
-	}); ok {
-		return d.DialContext(ctx, network, address)
-	}
-
-	type result struct {
-		conn net.Conn
-		err  error
-	}
-	resultCh := make(chan result, 1)
-	go func() {
-		conn, err := d.Dial(network, address)
-		resultCh <- result{conn: conn, err: err}
-	}()
-
-	select {
-	case result := <-resultCh:
-		return result.conn, result.err
-	case <-ctx.Done():
-		go func() {
-			result := <-resultCh
-			if result.conn != nil {
-				_ = result.conn.Close()
-			}
-		}()
-		return nil, ctx.Err()
-	}
 }


### PR DESCRIPTION
## Summary

- address the post-merge Qodo finding on PR #46
- move the duplicated proxy.Dialer cancellation adapter into dialer/internal/dialutil
- preserve native DialContext delegation and close late connections after cancellation
- cover native context propagation and cancellation cleanup

## Validation

- go test -race ./dialer/internal/dialutil ./dialer ./dialer/transport/ws
- go vet ./dialer/internal/dialutil ./dialer ./dialer/transport/ws
- Linux arm64 full suite: 18.1% coverage vs 17.9% master baseline
- Linux amd64 full suite: 18.4% coverage vs 18.2% master baseline