### PR TITLE
fix(v2ray): validate fuzzy boolean strings

### DIFF
--- a/dialer/v2ray/json_test.go
+++ b/dialer/v2ray/json_test.go
@@ -45,6 +45,10 @@ func TestFuzzyBool(t *testing.T) {
 		{input: `"0"`},
 		{input: `"true"`, want: true},
 		{input: `"false"`},
+		{input: `"yes"`, want: true},
+		{input: `"no"`},
+		{input: `"Y"`, want: true},
+		{input: `"N"`},
 		{input: "null"},
 	}
 	for _, test := range tests {
@@ -56,7 +60,7 @@ func TestFuzzyBool(t *testing.T) {
 		}
 	}
 
-	for _, input := range []string{"2", `{}`, `[]`} {
+	for _, input := range []string{"2", `"2"`, `"maybe"`, `{}`, `[]`} {
 		var got fuzzyBool
 		if err := json.Unmarshal([]byte(input), &got); err == nil {
 			t.Errorf("json.Unmarshal(%s) unexpectedly succeeded", input)
@@ -66,17 +70,22 @@ func TestFuzzyBool(t *testing.T) {
 
 func TestExportVmessURLRoundTrip(t *testing.T) {
 	want := &V2Ray{
-		Ps:       "node",
-		Add:      "proxy.example",
-		Port:     "443",
-		ID:       "00000000-0000-0000-0000-000000000001",
-		Aid:      "0",
-		Net:      "ws",
-		Type:     "none",
-		Host:     "front.example",
-		Path:     "/tunnel",
-		TLS:      "tls",
-		Protocol: "vmess",
+		Ps:            "node",
+		Add:           "proxy.example",
+		Port:          "443",
+		ID:            "00000000-0000-0000-0000-000000000001",
+		Aid:           "0",
+		Net:           "ws",
+		Type:          "none",
+		Host:          "front.example",
+		SNI:           "origin.example",
+		Path:          "/tunnel",
+		TLS:           "tls",
+		Flow:          "xtls-rprx-vision",
+		Alpn:          "h2,http/1.1",
+		AllowInsecure: true,
+		V:             "2",
+		Protocol:      "vmess",
 	}
 
 	got, err := ParseVmessURL(want.ExportToURL())

--- a/dialer/v2ray/v2ray.go
+++ b/dialer/v2ray/v2ray.go
@@ -84,13 +84,23 @@ func (b *fuzzyBool) UnmarshalJSON(data []byte) error {
 		if err := json.Unmarshal(data, &value); err != nil {
 			return err
 		}
-		*b = fuzzyBool(common.StringToBool(value))
-		return nil
+		switch strings.ToLower(value) {
+		case "true", "yes", "1", "y":
+			*b = true
+			return nil
+		case "false", "no", "0", "n":
+			*b = false
+			return nil
+		default:
+			return fmt.Errorf("expected boolean string, got %q", value)
+		}
 	}
 	return fmt.Errorf("expected boolean, 0, 1, string, or null")
 }
 
 func unmarshalV2Ray(data []byte, result *V2Ray) error {
+	// Keep this decoding mirror in sync with V2Ray; the full round-trip test
+	// covers every serializable field.
 	var decoded struct {
 		Ps            fuzzyString `json:"ps"`
 		Add           fuzzyString `json:"add"`


### PR DESCRIPTION
## Summary

- reject unknown quoted boolean values in VMess JSON instead of silently coercing them to false
- keep compatibility with the accepted true/false, yes/no, y/n, and 1/0 spellings
- exercise every serializable VMess field in the export/parse round-trip test

## Root cause

The fuzzy boolean decoder delegated arbitrary strings to a permissive helper, so malformed values such as `"maybe"` and `"2"` were accepted as false. The existing round-trip fixture also omitted several fields and could miss future decoder mapping drift.

## Validation

- `go test -race ./dialer/v2ray`
- `go vet ./dialer/v2ray`
- Linux arm64 full suite: 18.6% coverage (master baseline 17.9%)
- Linux amd64 full suite: 18.9% coverage (master baseline 18.2%)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * V2Ray configuration parsing now accepts additional boolean values, including “yes,” “no,” “y,” and “n,” regardless of capitalization.
  * VMess configuration import and export now preserve more connection settings during round trips.

* **Bug Fixes**
  * Invalid boolean values are rejected more reliably with clearer parsing errors, helping prevent unintended configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->