### PR TITLE
chore(renovate): validate updates through PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,13 @@
       "internalChecksFilter": "strict"
     },
     {
+      "description": "Keep the downstream fixture pointed at the local gg checkout",
+      "matchManagers": ["gomod"],
+      "matchFileNames": ["testdata/downstream/go.mod"],
+      "matchPackageNames": ["github.com/mzz2017/gg"],
+      "enabled": false
+    },
+    {
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "!/^0/",
       "automerge": true
@@ -33,7 +40,7 @@
       "minimumReleaseAge": null
     }
   ],
-  "automergeType": "branch",
+  "automergeType": "pr",
   "postUpdateOptions": [
     "gomodMassage",
     "gomodTidy"


### PR DESCRIPTION
## Summary

- use PR automerge so Renovate updates receive the repository's existing CI checks before merge
- keep the downstream compatibility fixture's `github.com/mzz2017/gg v0.0.0` local-checkout placeholder out of Renovate updates

## Root cause

The workflow runs for pull requests and pushes to `master`, but not for Renovate branch pushes. With branch automerge, `renovate/all-minor-patch` had no check runs and remained pending. The same branch also rewrote a fixture version that CI always replaces with the current workspace.

## Validation

- `jq empty renovate.json`
- `git diff --check`
- no production or test code changed; coverage is unaffected
