### PR TITLE
feat: add Hysteria2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ complete -c gg -x -a "(__fish_complete_gg_subcommand)"
 
 ### Protocol
 
+- [x] Hysteria2 (HY2)
 - [x] HTTP(S)
 - [x] Socks
   - [x] Socks4

--- a/README_zh.md
+++ b/README_zh.md
@@ -290,6 +290,7 @@ complete -c gg -x -a "(__fish_complete_gg_subcommand)"
 
 ### 协议类型
 
+- [x] Hysteria2 (HY2)
 - [x] HTTP(S)
 - [x] Socks5
 - [x] VMess(AEAD, alterID=0) / VLESS

--- a/cmd/subscription_test.go
+++ b/cmd/subscription_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/mzz2017/gg/dialer"
+	_ "github.com/mzz2017/gg/dialer/hysteria2"
 	_ "github.com/mzz2017/gg/dialer/socks"
 )
 
@@ -42,5 +43,21 @@ func TestResolveSubscriptionAsClash(t *testing.T) {
 				t.Fatal("expected UDP support")
 			}
 		})
+	}
+}
+
+func TestResolveSubscriptionAsBase64Hysteria2(t *testing.T) {
+	link := "hysteria2://secret@192.0.2.1:443?sni=proxy.example&insecure=1#hy2-node"
+	subscription := []byte(base64.StdEncoding.EncodeToString([]byte(link)))
+
+	dialers := resolveSubscriptionAsBase64(NewLogger(0), &dialer.GlobalOption{}, subscription)
+	if len(dialers) != 1 {
+		t.Fatalf("dialers = %d, want 1", len(dialers))
+	}
+	if got := dialers[0].Protocol(); got != "hysteria2" {
+		t.Fatalf("protocol = %q, want hysteria2", got)
+	}
+	if !dialers[0].SupportUDP() {
+		t.Fatal("expected UDP support")
 	}
 }

--- a/dialer/hysteria2/hysteria2.go
+++ b/dialer/hysteria2/hysteria2.go
@@ -33,12 +33,17 @@ func New(link string, option *dialer.GlobalOption) (*dialer.Dialer, error) {
 	if err != nil {
 		return nil, err
 	}
+	exportedLink := property.Link
+	if parsed, parseErr := url.Parse(exportedLink); parseErr == nil && parsed.User != nil && parsed.User.Username() == "" {
+		parsed.User = nil
+		exportedLink = parsed.String()
+	}
 	return dialer.NewDialer(
 		dialer.FromNetproxyDialer(proxyDialer),
 		true,
 		property.Name,
 		property.Protocol,
-		property.Link,
+		exportedLink,
 	), nil
 }
 
@@ -62,10 +67,14 @@ func NewFromClash(node *yaml.Node, option *dialer.GlobalOption) (*dialer.Dialer,
 	if proxy.SkipCertVerify {
 		query.Set("insecure", "1")
 	}
+	var user *url.Userinfo
+	if proxy.Password != "" {
+		user = url.User(proxy.Password)
+	}
 	link := url.URL{
 		Scheme:   "hysteria2",
 		Host:     net.JoinHostPort(proxy.Server, strconv.Itoa(proxy.Port)),
-		User:     url.User(proxy.Password),
+		User:     user,
 		RawQuery: query.Encode(),
 		Fragment: proxy.Name,
 	}

--- a/dialer/hysteria2/hysteria2.go
+++ b/dialer/hysteria2/hysteria2.go
@@ -1,0 +1,73 @@
+// Package hysteria2 adapts outbound's Hysteria2 dialer to gg.
+package hysteria2
+
+import (
+	"net"
+	"net/url"
+	"strconv"
+
+	outbounddialer "github.com/daeuniverse/outbound/dialer"
+	outboundhysteria2 "github.com/daeuniverse/outbound/dialer/hysteria2"
+	_ "github.com/daeuniverse/outbound/protocol/hysteria2"
+	"github.com/mzz2017/gg/dialer"
+	"gopkg.in/yaml.v3"
+)
+
+func init() {
+	dialer.FromLinkRegister("hysteria2", New)
+	dialer.FromLinkRegister("hy2", New)
+	dialer.FromClashRegister("hysteria2", NewFromClash)
+}
+
+// New creates a Hysteria2 dialer from a share link.
+func New(link string, option *dialer.GlobalOption) (*dialer.Dialer, error) {
+	extra := &outbounddialer.ExtraOption{}
+	if option != nil {
+		extra.AllowInsecure = option.AllowInsecure
+	}
+	proxyDialer, property, err := outboundhysteria2.NewHysteria2(
+		extra,
+		dialer.ToNetproxyDialer(dialer.SymmetricDirect),
+		link,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return dialer.NewDialer(
+		dialer.FromNetproxyDialer(proxyDialer),
+		true,
+		property.Name,
+		property.Protocol,
+		property.Link,
+	), nil
+}
+
+// NewFromClash creates a Hysteria2 dialer from a Clash proxy entry.
+func NewFromClash(node *yaml.Node, option *dialer.GlobalOption) (*dialer.Dialer, error) {
+	var proxy struct {
+		Name           string `yaml:"name"`
+		Server         string `yaml:"server"`
+		Port           int    `yaml:"port"`
+		Password       string `yaml:"password"`
+		SNI            string `yaml:"sni"`
+		SkipCertVerify bool   `yaml:"skip-cert-verify"`
+	}
+	if err := node.Decode(&proxy); err != nil {
+		return nil, err
+	}
+	query := url.Values{}
+	if proxy.SNI != "" {
+		query.Set("sni", proxy.SNI)
+	}
+	if proxy.SkipCertVerify {
+		query.Set("insecure", "1")
+	}
+	link := url.URL{
+		Scheme:   "hysteria2",
+		Host:     net.JoinHostPort(proxy.Server, strconv.Itoa(proxy.Port)),
+		User:     url.User(proxy.Password),
+		RawQuery: query.Encode(),
+		Fragment: proxy.Name,
+	}
+	return New(link.String(), option)
+}

--- a/dialer/hysteria2/hysteria2_test.go
+++ b/dialer/hysteria2/hysteria2_test.go
@@ -1,0 +1,40 @@
+package hysteria2
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/mzz2017/gg/dialer"
+	"gopkg.in/yaml.v3"
+)
+
+func TestNew(t *testing.T) {
+	got, err := New("hysteria2://password@192.0.2.1:443?sni=proxy.example&insecure=1#hy2-node", &dialer.GlobalOption{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name() != "hy2-node" || got.Protocol() != "hysteria2" {
+		t.Fatalf("metadata = (%q, %q)", got.Name(), got.Protocol())
+	}
+	if !got.SupportUDP() {
+		t.Fatal("expected UDP support")
+	}
+	parsed, err := url.Parse(got.Link())
+	if err != nil || parsed.Scheme != "hysteria2" {
+		t.Fatalf("exported link = %q", got.Link())
+	}
+}
+
+func TestNewFromClash(t *testing.T) {
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte("name: clash-hy2\ntype: hysteria2\nserver: 192.0.2.1\nport: 443\npassword: secret\nsni: proxy.example\nskip-cert-verify: true\n"), &node); err != nil {
+		t.Fatal(err)
+	}
+	got, err := NewFromClash(&node, &dialer.GlobalOption{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name() != "clash-hy2" || !got.SupportUDP() {
+		t.Fatalf("metadata = (%q, udp=%v)", got.Name(), got.SupportUDP())
+	}
+}

--- a/dialer/hysteria2/hysteria2_test.go
+++ b/dialer/hysteria2/hysteria2_test.go
@@ -38,3 +38,19 @@ func TestNewFromClash(t *testing.T) {
 		t.Fatalf("metadata = (%q, udp=%v)", got.Name(), got.SupportUDP())
 	}
 }
+
+func TestNewFromClashWithoutPassword(t *testing.T) {
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte("name: clash-hy2\ntype: hysteria2\nserver: 192.0.2.1\nport: 443\n"), &node); err != nil {
+		t.Fatal(err)
+	}
+	got, err := NewFromClash(&node, &dialer.GlobalOption{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed, err := url.Parse(got.Link()); err != nil {
+		t.Fatal(err)
+	} else if parsed.User != nil {
+		t.Fatalf("unexpected empty user info in link %q", got.Link())
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/mzz2017/disk-bloom v1.0.1 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/onsi/ginkgo/v2 v2.22.2 // indirect
+	github.com/quic-go/qpack v0.5.1 // indirect
 	github.com/refraction-networking/utls v1.8.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdD
 github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/quic-go/qpack v0.5.1 h1:giqksBPnT/HDtZ6VhtFKgoLOWmlyo9Ei6u9PqzIMbhI=
+github.com/quic-go/qpack v0.5.1/go.mod h1:+PC4XFrEskIVkcLzpEkbLqq1uCoxPhQuvK5rH1ZgaEg=
 github.com/refraction-networking/utls v1.8.2 h1:j4Q1gJj0xngdeH+Ox/qND11aEfhpgoEvV+S9iJ2IdQo=
 github.com/refraction-networking/utls v1.8.2/go.mod h1:jkSOEkLqn+S/jtpEHPOsVv/4V4EVnelwbMQl4vCWXAM=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/daeuniverse/outbound/protocol/vmess"
 	"github.com/mzz2017/gg/cmd"
 	_ "github.com/mzz2017/gg/dialer/http"
+	_ "github.com/mzz2017/gg/dialer/hysteria2"
 	_ "github.com/mzz2017/gg/dialer/shadowsocks"
 	_ "github.com/mzz2017/gg/dialer/shadowsocksr"
 	_ "github.com/mzz2017/gg/dialer/socks"


### PR DESCRIPTION
## Summary

- add Hysteria2 and `hy2` share-link support through `github.com/daeuniverse/outbound`
- convert Hysteria2 Clash subscription entries and report UDP capability
- document the protocol and add link/subscription parsing tests

## Validation

- Linux arm64 Docker: `go test -race ./dialer/hysteria2 ./cmd`
- Real cached subscription nodes in Linux arm64 Docker: 3/3 Hysteria2 nodes reached `generate_204`

This PR is intentionally limited to Hysteria2. AnyTLS is being developed and reviewed separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Hysteria2 (HY2) proxy connections.
  * Supports Hysteria2 share links and Clash configuration imports.
  * Hysteria2 connections include UDP support and configurable security settings.

* **Documentation**
  * Updated English and Chinese protocol support lists to include Hysteria2 (HY2).

* **Bug Fixes**
  * Improved recognition and resolution of Hysteria2 subscription links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->