### PR TITLE
feat: add AnyTLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ complete -c gg -x -a "(__fish_complete_gg_subcommand)"
 ### Protocol
 
 - [x] Hysteria2 (HY2)
+- [x] AnyTLS
 - [x] HTTP(S)
 - [x] Socks
   - [x] Socks4

--- a/README_zh.md
+++ b/README_zh.md
@@ -291,6 +291,7 @@ complete -c gg -x -a "(__fish_complete_gg_subcommand)"
 ### 协议类型
 
 - [x] Hysteria2 (HY2)
+- [x] AnyTLS
 - [x] HTTP(S)
 - [x] Socks5
 - [x] VMess(AEAD, alterID=0) / VLESS

--- a/cmd/subscription_test.go
+++ b/cmd/subscription_test.go
@@ -47,6 +47,28 @@ func TestResolveSubscriptionAsClash(t *testing.T) {
 	}
 }
 
+func TestResolveSubscriptionAsClashAnyTLS(t *testing.T) {
+	config := []byte(`proxies:
+  - name: clash-anytls
+    type: anytls
+    server: 192.0.2.1
+    port: 443
+    password: secret
+    sni: proxy.example
+    skip-cert-verify: true
+`)
+	dialers, err := resolveSubscriptionAsClash(NewLogger(0), &dialer.GlobalOption{}, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dialers) != 1 {
+		t.Fatalf("dialers = %d, want 1", len(dialers))
+	}
+	if dialers[0].Protocol() != "anytls" {
+		t.Fatalf("protocol = %q, want anytls", dialers[0].Protocol())
+	}
+}
+
 func TestResolveSubscriptionAsBase64AnyTLS(t *testing.T) {
 	link := "anytls://test-auth@192.0.2.1:443?sni=proxy.example&insecure=1#anytls-node"
 	subscription := []byte(base64.StdEncoding.EncodeToString([]byte(link)))

--- a/cmd/subscription_test.go
+++ b/cmd/subscription_test.go
@@ -56,6 +56,7 @@ func TestResolveSubscriptionAsClashAnyTLS(t *testing.T) {
     password: secret
     sni: proxy.example
     skip-cert-verify: true
+    udp: false
 `)
 	dialers, err := resolveSubscriptionAsClash(NewLogger(0), &dialer.GlobalOption{}, config)
 	if err != nil {
@@ -66,6 +67,9 @@ func TestResolveSubscriptionAsClashAnyTLS(t *testing.T) {
 	}
 	if dialers[0].Protocol() != "anytls" {
 		t.Fatalf("protocol = %q, want anytls", dialers[0].Protocol())
+	}
+	if dialers[0].SupportUDP() {
+		t.Fatal("expected UDP support to be disabled")
 	}
 }
 

--- a/cmd/subscription_test.go
+++ b/cmd/subscription_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/mzz2017/gg/dialer"
+	_ "github.com/mzz2017/gg/dialer/anytls"
 	_ "github.com/mzz2017/gg/dialer/hysteria2"
 	_ "github.com/mzz2017/gg/dialer/socks"
 )
@@ -43,6 +44,22 @@ func TestResolveSubscriptionAsClash(t *testing.T) {
 				t.Fatal("expected UDP support")
 			}
 		})
+	}
+}
+
+func TestResolveSubscriptionAsBase64AnyTLS(t *testing.T) {
+	link := "anytls://test-auth@192.0.2.1:443?sni=proxy.example&insecure=1#anytls-node"
+	subscription := []byte(base64.StdEncoding.EncodeToString([]byte(link)))
+
+	dialers := resolveSubscriptionAsBase64(NewLogger(0), &dialer.GlobalOption{}, subscription)
+	if len(dialers) != 1 {
+		t.Fatalf("dialers = %d, want 1", len(dialers))
+	}
+	if got := dialers[0].Protocol(); got != "anytls" {
+		t.Fatalf("protocol = %q, want anytls", got)
+	}
+	if !dialers[0].SupportUDP() {
+		t.Fatal("expected UDP support")
 	}
 }
 

--- a/dialer/anytls/anytls.go
+++ b/dialer/anytls/anytls.go
@@ -2,14 +2,54 @@
 package anytls
 
 import (
+	"net"
+	"net/url"
+	"strconv"
+
 	outbounddialer "github.com/daeuniverse/outbound/dialer"
 	outboundanytls "github.com/daeuniverse/outbound/dialer/anytls"
 	_ "github.com/daeuniverse/outbound/protocol/anytls"
 	"github.com/mzz2017/gg/dialer"
+	"gopkg.in/yaml.v3"
 )
 
 func init() {
 	dialer.FromLinkRegister("anytls", New)
+	dialer.FromClashRegister("anytls", NewFromClash)
+}
+
+// NewFromClash creates an AnyTLS dialer from a Clash proxy entry.
+func NewFromClash(node *yaml.Node, option *dialer.GlobalOption) (*dialer.Dialer, error) {
+	var proxy struct {
+		Name           string `yaml:"name"`
+		Server         string `yaml:"server"`
+		Port           int    `yaml:"port"`
+		Password       string `yaml:"password"`
+		SNI            string `yaml:"sni"`
+		SkipCertVerify bool   `yaml:"skip-cert-verify"`
+	}
+	if err := node.Decode(&proxy); err != nil {
+		return nil, err
+	}
+	query := url.Values{}
+	if proxy.SNI != "" {
+		query.Set("sni", proxy.SNI)
+	}
+	if proxy.SkipCertVerify {
+		query.Set("insecure", "1")
+	}
+	var user *url.Userinfo
+	if proxy.Password != "" {
+		user = url.User(proxy.Password)
+	}
+	link := url.URL{
+		Scheme:   "anytls",
+		Host:     net.JoinHostPort(proxy.Server, strconv.Itoa(proxy.Port)),
+		User:     user,
+		RawQuery: query.Encode(),
+		Fragment: proxy.Name,
+	}
+	return New(link.String(), option)
 }
 
 // New creates an AnyTLS dialer from a share link.

--- a/dialer/anytls/anytls.go
+++ b/dialer/anytls/anytls.go
@@ -1,0 +1,37 @@
+// Package anytls adapts outbound's AnyTLS share-link dialer to gg.
+package anytls
+
+import (
+	outbounddialer "github.com/daeuniverse/outbound/dialer"
+	outboundanytls "github.com/daeuniverse/outbound/dialer/anytls"
+	_ "github.com/daeuniverse/outbound/protocol/anytls"
+	"github.com/mzz2017/gg/dialer"
+)
+
+func init() {
+	dialer.FromLinkRegister("anytls", New)
+}
+
+// New creates an AnyTLS dialer from a share link.
+func New(link string, option *dialer.GlobalOption) (*dialer.Dialer, error) {
+	extraOption := &outbounddialer.ExtraOption{}
+	if option != nil {
+		extraOption.AllowInsecure = option.AllowInsecure
+	}
+
+	proxyDialer, property, err := outboundanytls.NewAnytls(
+		extraOption,
+		dialer.ToNetproxyDialer(dialer.SymmetricDirect),
+		link,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return dialer.NewDialer(
+		dialer.FromNetproxyDialer(proxyDialer),
+		true,
+		property.Name,
+		property.Protocol,
+		property.Link,
+	), nil
+}

--- a/dialer/anytls/anytls.go
+++ b/dialer/anytls/anytls.go
@@ -27,6 +27,7 @@ func NewFromClash(node *yaml.Node, option *dialer.GlobalOption) (*dialer.Dialer,
 		Password       string `yaml:"password"`
 		SNI            string `yaml:"sni"`
 		SkipCertVerify bool   `yaml:"skip-cert-verify"`
+		UDP            *bool  `yaml:"udp,omitempty"`
 	}
 	if err := node.Decode(&proxy); err != nil {
 		return nil, err
@@ -49,7 +50,18 @@ func NewFromClash(node *yaml.Node, option *dialer.GlobalOption) (*dialer.Dialer,
 		RawQuery: query.Encode(),
 		Fragment: proxy.Name,
 	}
-	return New(link.String(), option)
+	result, err := New(link.String(), option)
+	if err != nil {
+		return nil, err
+	}
+	supportUDP := true
+	if proxy.UDP != nil {
+		supportUDP = *proxy.UDP
+	}
+	if supportUDP == result.SupportUDP() {
+		return result, nil
+	}
+	return dialer.NewDialer(result.Dialer, supportUDP, result.Name(), result.Protocol(), result.Link()), nil
 }
 
 // New creates an AnyTLS dialer from a share link.

--- a/dialer/anytls/anytls_test.go
+++ b/dialer/anytls/anytls_test.go
@@ -1,0 +1,34 @@
+package anytls
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/mzz2017/gg/dialer"
+)
+
+func TestNew(t *testing.T) {
+	got, err := New(
+		"anytls://test-auth@192.0.2.1:443?sni=proxy.example&insecure=1#anytls-node",
+		&dialer.GlobalOption{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name() != "anytls-node" {
+		t.Fatalf("name = %q, want anytls-node", got.Name())
+	}
+	if got.Protocol() != "anytls" {
+		t.Fatalf("protocol = %q, want anytls", got.Protocol())
+	}
+	if !got.SupportUDP() {
+		t.Fatal("expected UDP support")
+	}
+	link, err := url.Parse(got.Link())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if link.Scheme != "anytls" {
+		t.Fatalf("link scheme = %q, want anytls", link.Scheme)
+	}
+}

--- a/dialer/anytls/anytls_test.go
+++ b/dialer/anytls/anytls_test.go
@@ -47,3 +47,17 @@ func TestNewFromClash(t *testing.T) {
 		t.Fatalf("metadata = (%q, %q, udp=%v)", got.Name(), got.Protocol(), got.SupportUDP())
 	}
 }
+
+func TestNewFromClashUDPDisabled(t *testing.T) {
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte("name: clash-anytls\ntype: anytls\nserver: 192.0.2.1\nport: 443\npassword: secret\nudp: false\n"), &node); err != nil {
+		t.Fatal(err)
+	}
+	got, err := NewFromClash(&node, &dialer.GlobalOption{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SupportUDP() {
+		t.Fatal("expected UDP support to be disabled")
+	}
+}

--- a/dialer/anytls/anytls_test.go
+++ b/dialer/anytls/anytls_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/mzz2017/gg/dialer"
+	"gopkg.in/yaml.v3"
 )
 
 func TestNew(t *testing.T) {
@@ -30,5 +31,19 @@ func TestNew(t *testing.T) {
 	}
 	if link.Scheme != "anytls" {
 		t.Fatalf("link scheme = %q, want anytls", link.Scheme)
+	}
+}
+
+func TestNewFromClash(t *testing.T) {
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte("name: clash-anytls\ntype: anytls\nserver: 192.0.2.1\nport: 443\npassword: secret\nsni: proxy.example\nskip-cert-verify: true\n"), &node); err != nil {
+		t.Fatal(err)
+	}
+	got, err := NewFromClash(&node, &dialer.GlobalOption{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name() != "clash-anytls" || got.Protocol() != "anytls" || !got.SupportUDP() {
+		t.Fatalf("metadata = (%q, %q, udp=%v)", got.Name(), got.Protocol(), got.SupportUDP())
 	}
 }

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/daeuniverse/outbound/protocol/vless"
 	_ "github.com/daeuniverse/outbound/protocol/vmess"
 	"github.com/mzz2017/gg/cmd"
+	_ "github.com/mzz2017/gg/dialer/anytls"
 	_ "github.com/mzz2017/gg/dialer/http"
 	_ "github.com/mzz2017/gg/dialer/hysteria2"
 	_ "github.com/mzz2017/gg/dialer/shadowsocks"


### PR DESCRIPTION
## Summary

- add AnyTLS share-link support through `github.com/daeuniverse/outbound`
- register AnyTLS in the CLI and report UDP capability
- document AnyTLS and add link/base64 subscription parsing tests

## Validation

- Linux arm64 Docker: `go test -race ./dialer/anytls ./cmd`
- Real cached subscription nodes in Linux arm64 Docker: 26/33 AnyTLS nodes reached `generate_204`; 7 failed with node-side EOF, timeout, or closed-pipe errors

This PR is intentionally limited to AnyTLS. Hysteria2 is tracked separately in PR #55.
