### PR TITLE
fix: honor Hysteria2 Clash UDP setting

### DIFF
--- a/dialer/hysteria2/hysteria2.go
+++ b/dialer/hysteria2/hysteria2.go
@@ -56,6 +56,7 @@ func NewFromClash(node *yaml.Node, option *dialer.GlobalOption) (*dialer.Dialer,
 		Password       string `yaml:"password"`
 		SNI            string `yaml:"sni"`
 		SkipCertVerify bool   `yaml:"skip-cert-verify"`
+		UDP            *bool  `yaml:"udp,omitempty"`
 	}
 	if err := node.Decode(&proxy); err != nil {
 		return nil, err
@@ -78,5 +79,16 @@ func NewFromClash(node *yaml.Node, option *dialer.GlobalOption) (*dialer.Dialer,
 		RawQuery: query.Encode(),
 		Fragment: proxy.Name,
 	}
-	return New(link.String(), option)
+	result, err := New(link.String(), option)
+	if err != nil {
+		return nil, err
+	}
+	supportUDP := true
+	if proxy.UDP != nil {
+		supportUDP = *proxy.UDP
+	}
+	if supportUDP == result.SupportUDP() {
+		return result, nil
+	}
+	return dialer.NewDialer(result.Dialer, supportUDP, result.Name(), result.Protocol(), result.Link()), nil
 }

--- a/dialer/hysteria2/hysteria2_test.go
+++ b/dialer/hysteria2/hysteria2_test.go
@@ -54,3 +54,17 @@ func TestNewFromClashWithoutPassword(t *testing.T) {
 		t.Fatalf("unexpected empty user info in link %q", got.Link())
 	}
 }
+
+func TestNewFromClashUDPDisabled(t *testing.T) {
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte("name: clash-hy2\ntype: hysteria2\nserver: 192.0.2.1\nport: 443\npassword: secret\nudp: false\n"), &node); err != nil {
+		t.Fatal(err)
+	}
+	got, err := NewFromClash(&node, &dialer.GlobalOption{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.SupportUDP() {
+		t.Fatal("expected UDP support to be disabled")
+	}
+}


### PR DESCRIPTION
## Summary

- honor an explicit `udp` value in Hysteria2 Clash entries
- preserve UDP support by default when `udp` is omitted
- add regression coverage for `udp: false`

This is a follow-up to PR #55 and addresses the Qodo review finding without modifying the merged PR.

## Validation

- Linux arm64 Docker: `go test -race ./dialer/hysteria2 ./cmd`
- Linux arm64 Docker: `go test ./...`
- Real cached Hysteria2 subscription e2e in Linux arm64 Docker: 3/3 nodes reached `generate_204`
