### PR TITLE
fix: clarify disabled UDP redirection

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -99,9 +99,7 @@ $ gg git clone https://github.com/mzz2017/gg.git`)
 			} else {
 				noUDP = v.GetBool("no_udp")
 			}
-			if !noUDP && !dialer.SupportUDP() {
-				log.Info("Your proxy server does not support UDP, so we will not redirect UDP traffic.")
-			}
+			logUDPRedirectLimitation(log, noUDP, dialer.SupportUDP())
 			// Get proxy_private from argument first, then from configuration file.
 			var proxyPrivate bool
 			proxyPrivateFlag := cmd.Flags().Lookup("proxyprivate")
@@ -166,6 +164,12 @@ func init() {
 func configureCommandPassthrough(command *cobra.Command) {
 	command.Args = cobra.ArbitraryArgs
 	command.Flags().SetInterspersed(false)
+}
+
+func logUDPRedirectLimitation(log *logrus.Logger, noUDP, supportUDP bool) {
+	if !noUDP && !supportUDP {
+		log.Info("UDP redirection is disabled or unsupported for this node; DNS traffic may still be handled.")
+	}
 }
 
 func NewLogger(verbose int) *logrus.Logger {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,11 +1,43 @@
 package cmd
 
 import (
+	"bytes"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 )
+
+func TestLogUDPRedirectLimitation(t *testing.T) {
+	tests := []struct {
+		name       string
+		noUDP      bool
+		supportUDP bool
+		wantLog    bool
+	}{
+		{name: "node disabled", supportUDP: false, wantLog: true},
+		{name: "node supports UDP", supportUDP: true},
+		{name: "globally disabled", noUDP: true, supportUDP: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var output bytes.Buffer
+			log := NewLogger(1)
+			log.SetOutput(&output)
+
+			logUDPRedirectLimitation(log, test.noUDP, test.supportUDP)
+
+			got := output.String()
+			if test.wantLog != (got != "") {
+				t.Fatalf("log output = %q, wantLog = %v", got, test.wantLog)
+			}
+			if test.wantLog && (!strings.Contains(got, "disabled or unsupported") || !strings.Contains(got, "DNS traffic may still be handled")) {
+				t.Fatalf("log output = %q", got)
+			}
+		})
+	}
+}
 
 func TestCommandArgumentsPassThroughUnchanged(t *testing.T) {
 	var (


### PR DESCRIPTION
## Summary

- replace the misleading claim that the proxy server does not support UDP
- explain that UDP may be disabled by node configuration and that DNS traffic may still be handled
- test logging for node-disabled, supported, and globally-disabled cases

This follows up on the Qodo review submitted after PR #57 was merged. The post-merge review timelines for PRs #55-#57 were audited; the other findings were already resolved by PRs #56 and #57.

## Validation

- Linux arm64 Docker: `go test -race ./cmd`
- Linux arm64 Docker: `go test ./...`
- Real Hysteria2 e2e in Linux arm64 Docker: 3/3 nodes reached `generate_204`
- Real AnyTLS e2e in Linux arm64 Docker: 27/33 nodes reached `generate_204`; remaining failures were node-side closed-pipe or timeout errors
- sensitive subscription URL/token audit: clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved messaging when UDP redirection is unavailable for a selected node.
  * Clarified that DNS traffic may still be handled even when UDP redirection is disabled or unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->