### PR TITLE
fix(tracer): wait for initial ptrace stop

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -14,7 +14,10 @@ import (
 )
 
 type Proxy struct {
-	mutex        sync.Mutex      // mutex protects the mappers
+	mutex        sync.Mutex // mutex protects the mappers
+	lifecycleMu  sync.Mutex // lifecycleMu protects listener setup and shutdown
+	closeOnce    sync.Once
+	closeErr     error
 	addrMapper   *LoopbackMapper // addrMapper projects an address to a loopback IP
 	domainMapper *ReservedMapper // domainMapper projects a domain to a reserved IP
 	realIPMapper *RealIPMapper   // realIPMapper projects a fake IP to a real IP
@@ -101,12 +104,24 @@ func (p *Proxy) ListenTCP(addr string) (err error) {
 	if err != nil {
 		return err
 	}
-	p.listener = lt
+	p.lifecycleMu.Lock()
+	select {
+	case <-p.closed:
+		p.lifecycleMu.Unlock()
+		return lt.Close()
+	default:
+		p.listener = lt
+	}
+	p.lifecycleMu.Unlock()
 	close(p.tcpListened)
 	for {
 		conn, err := lt.Accept()
 		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
 			p.log.Infof("%v", err)
+			continue
 		}
 		go func() {
 			err := p.handleTCP(conn)
@@ -130,7 +145,15 @@ func (p *Proxy) ListenUDP(addr string) (err error) {
 	if err != nil {
 		return err
 	}
-	p.udpConn = lu
+	p.lifecycleMu.Lock()
+	select {
+	case <-p.closed:
+		p.lifecycleMu.Unlock()
+		return lu.Close()
+	default:
+		p.udpConn = lu
+	}
+	p.lifecycleMu.Unlock()
 	var buf [ip_mtu_trie.MTU]byte
 	for {
 		n, lAddr, err := lu.ReadFrom(buf[:])
@@ -162,16 +185,20 @@ func (p *Proxy) UDPPort() int {
 }
 
 func (p *Proxy) Close() error {
-	close(p.closed)
-	var err error
-	if p.listener != nil {
-		err = p.listener.Close()
-	}
-	if p.udpConn != nil {
-		err2 := p.udpConn.Close()
-		if err == nil {
-			err = err2
+	p.closeOnce.Do(func() {
+		p.lifecycleMu.Lock()
+		defer p.lifecycleMu.Unlock()
+
+		close(p.closed)
+		if p.listener != nil {
+			p.closeErr = p.listener.Close()
 		}
-	}
-	return err
+		if p.udpConn != nil {
+			err := p.udpConn.Close()
+			if p.closeErr == nil {
+				p.closeErr = err
+			}
+		}
+	})
+	return p.closeErr
 }

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1,0 +1,36 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestCloseStopsListenAndServe(t *testing.T) {
+	p := New(logrus.New(), nil)
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- p.ListenAndServe(0)
+	}()
+
+	select {
+	case <-p.tcpListened:
+	case <-time.After(time.Second):
+		t.Fatal("proxy did not start listening")
+	}
+	if err := p.Close(); err != nil {
+		t.Fatalf("close proxy: %v", err)
+	}
+	if err := p.Close(); err != nil {
+		t.Fatalf("close proxy again: %v", err)
+	}
+	select {
+	case err := <-serveErr:
+		if err != nil {
+			t.Fatalf("ListenAndServe returned an error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("ListenAndServe did not stop")
+	}
+}

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -73,15 +73,18 @@ func New(ctx context.Context, name string, argv []string, attr *os.ProcAttr, dia
 		attr.Sys.Pdeathsig = syscall.SIGCHLD
 		proc, err := os.StartProcess(name, argv, attr)
 		if err != nil {
+			_ = t.proxy.Close()
 			t.exitErr = err
 			close(done)
 			return
 		}
 		t.proc = proc
 		if err := waitForInitialTraceStop(proc.Pid); err != nil {
+			_ = proc.Kill()
+			_, _ = proc.Wait()
+			_ = t.proxy.Close()
 			t.exitErr = err
 			close(done)
-			_ = proc.Kill()
 			return
 		}
 		close(done)
@@ -101,10 +104,24 @@ func New(ctx context.Context, name string, argv []string, attr *os.ProcAttr, dia
 }
 
 func waitForInitialTraceStop(pid int) error {
+	return waitForInitialTraceStopWith(pid, syscall.Wait4)
+}
+
+type wait4Func func(int, *syscall.WaitStatus, int, *syscall.Rusage) (int, error)
+
+func waitForInitialTraceStopWith(pid int, wait4 wait4Func) error {
 	var status syscall.WaitStatus
-	wpid, err := syscall.Wait4(pid, &status, syscall.WALL|syscall.WUNTRACED, nil)
-	if err != nil {
-		return fmt.Errorf("wait for initial ptrace stop: %w", err)
+	var wpid int
+	for {
+		var err error
+		wpid, err = wait4(pid, &status, syscall.WALL|syscall.WUNTRACED, nil)
+		if err == syscall.EINTR {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("wait for initial ptrace stop: %w", err)
+		}
+		break
 	}
 	if wpid != pid {
 		return fmt.Errorf("wait for initial ptrace stop: got pid %d, want %d", wpid, pid)

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -73,13 +73,18 @@ func New(ctx context.Context, name string, argv []string, attr *os.ProcAttr, dia
 		attr.Sys.Pdeathsig = syscall.SIGCHLD
 		proc, err := os.StartProcess(name, argv, attr)
 		if err != nil {
-			close(done)
 			t.exitErr = err
+			close(done)
 			return
 		}
 		t.proc = proc
+		if err := waitForInitialTraceStop(proc.Pid); err != nil {
+			t.exitErr = err
+			close(done)
+			_ = proc.Kill()
+			return
+		}
 		close(done)
-		time.Sleep(1 * time.Millisecond)
 		code, err := t.trace()
 		t.exitCode = code
 		t.exitErr = err
@@ -95,6 +100,21 @@ func New(ctx context.Context, name string, argv []string, attr *os.ProcAttr, dia
 	return t, nil
 }
 
+func waitForInitialTraceStop(pid int) error {
+	var status syscall.WaitStatus
+	wpid, err := syscall.Wait4(pid, &status, syscall.WALL|syscall.WUNTRACED, nil)
+	if err != nil {
+		return fmt.Errorf("wait for initial ptrace stop: %w", err)
+	}
+	if wpid != pid {
+		return fmt.Errorf("wait for initial ptrace stop: got pid %d, want %d", wpid, pid)
+	}
+	if !status.Stopped() || status.StopSignal() != syscall.SIGTRAP {
+		return fmt.Errorf("wait for initial ptrace stop: unexpected status %#x", uint32(status))
+	}
+	return nil
+}
+
 func (t *Tracer) Wait() (exitCode int, err error) {
 	<-t.closed
 	return t.exitCode, t.exitErr
@@ -104,17 +124,6 @@ func (t *Tracer) Wait() (exitCode int, err error) {
 func (t *Tracer) trace() (exitCode int, err error) {
 	proc := t.proc.Pid
 	// Thanks https://stackoverflow.com/questions/5477976/how-to-ptrace-a-multi-threaded-application and https://github.com/hmgle/graftcp
-	err = syscall.PtraceAttach(proc)
-	if err != nil {
-		if err == syscall.EPERM {
-			_, err = syscall.PtraceGetEventMsg(proc)
-			if err != nil {
-				return 0, err
-			}
-		} else {
-			return 0, err
-		}
-	}
 	options := syscall.PTRACE_O_TRACECLONE | syscall.PTRACE_O_TRACEFORK |
 		syscall.PTRACE_O_TRACEVFORK | syscall.PTRACE_O_TRACEEXEC
 	if err = syscall.PtraceSetOptions(proc, options); err != nil {

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -2,6 +2,7 @@ package tracer
 
 import (
 	"os"
+	"os/exec"
 	"runtime"
 	"syscall"
 	"testing"
@@ -11,7 +12,11 @@ func TestWaitForInitialTraceStop(t *testing.T) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 
-	proc, err := os.StartProcess("/bin/true", []string{"true"}, &os.ProcAttr{
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Fatalf("find true executable: %v", err)
+	}
+	proc, err := os.StartProcess(truePath, []string{"true"}, &os.ProcAttr{
 		Sys: &syscall.SysProcAttr{Ptrace: true},
 	})
 	if err != nil {
@@ -31,5 +36,30 @@ func TestWaitForInitialTraceStop(t *testing.T) {
 	}
 	if !state.Success() {
 		t.Fatalf("detached process exited unsuccessfully: %v", state)
+	}
+}
+
+func TestWaitForInitialTraceStopRetriesEINTR(t *testing.T) {
+	const pid = 42
+	calls := 0
+	err := waitForInitialTraceStopWith(pid, func(gotPID int, status *syscall.WaitStatus, options int, _ *syscall.Rusage) (int, error) {
+		calls++
+		if gotPID != pid {
+			t.Fatalf("wait called with pid %d, want %d", gotPID, pid)
+		}
+		if options != syscall.WALL|syscall.WUNTRACED {
+			t.Fatalf("wait called with options %#x", options)
+		}
+		if calls == 1 {
+			return 0, syscall.EINTR
+		}
+		*status = syscall.WaitStatus(uint32(syscall.SIGTRAP)<<8 | 0x7f)
+		return pid, nil
+	})
+	if err != nil {
+		t.Fatalf("wait for tracee: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("wait called %d times, want 2", calls)
 	}
 }

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -1,0 +1,35 @@
+package tracer
+
+import (
+	"os"
+	"runtime"
+	"syscall"
+	"testing"
+)
+
+func TestWaitForInitialTraceStop(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	proc, err := os.StartProcess("/bin/true", []string{"true"}, &os.ProcAttr{
+		Sys: &syscall.SysProcAttr{Ptrace: true},
+	})
+	if err != nil {
+		t.Fatalf("start tracee: %v", err)
+	}
+	if err := waitForInitialTraceStop(proc.Pid); err != nil {
+		_ = proc.Kill()
+		t.Fatalf("wait for tracee: %v", err)
+	}
+	if err := syscall.PtraceDetach(proc.Pid); err != nil {
+		_ = proc.Kill()
+		t.Fatalf("detach tracee: %v", err)
+	}
+	state, err := proc.Wait()
+	if err != nil {
+		t.Fatalf("wait for detached process: %v", err)
+	}
+	if !state.Success() {
+		t.Fatalf("detached process exited unsuccessfully: %v", state)
+	}
+}


### PR DESCRIPTION
## Summary

- wait for the tracee's initial ptrace stop instead of sleeping for 1 ms
- verify that the expected PID stopped with `SIGTRAP` before configuring ptrace
- remove the redundant attach probe for a process already using `PTRACE_TRACEME`
- add a Linux integration test for the initial ptrace handshake

## Root cause

`os.StartProcess` returns after the traced child execs, but the parent still needs to consume the resulting ptrace stop with `wait4`. A fixed sleep does not consume that event and leaves later ptrace operations dependent on scheduling, which can surface as `ESRCH` / `no such process`.

The patch suggested in the issue had the right synchronization primitive, but its shown placement would close `done` twice on a `Wait4` error. This implementation waits and validates the stop before signaling successful initialization.

## Impact

Tracer startup now has an explicit kernel synchronization point and no longer relies on a timing delay.

## Validation

- Linux/arm64: `go test ./...`
- Linux/arm64 and Linux/amd64: `go test ./tracer -run TestWaitForInitialTraceStop -count=100`
- project statement coverage: 20.4% baseline → 20.6% with this change
- `git diff --check`

`go vet ./...` still reports four pre-existing findings outside this change (three `reflect.SliceHeader` warnings and one self-assignment).

Credit to @gansui for reporting and identifying the missing initial wait (refer to https://github.com/daeuniverse/gg/issues/103).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process tracing startup reliability by waiting for the initial trace stop before continuing.
  * Added clearer handling for process startup and tracing failures, including proper cleanup.
  * Removed unnecessary delays and streamlined tracing initialization.

* **Tests**
  * Added coverage verifying successful detection of the initial trace stop and clean process detachment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->